### PR TITLE
하단 네비게이션 바 구현

### DIFF
--- a/src/components/layouts/navigationBar.tsx
+++ b/src/components/layouts/navigationBar.tsx
@@ -1,0 +1,45 @@
+import { useTranslation } from 'react-i18next';
+import { BsPerson } from 'react-icons/bs';
+import { GoHome, GoSearch } from 'react-icons/go';
+import { PiMoon, PiClipboard } from 'react-icons/pi';
+import { Link } from 'react-router-dom';
+
+export default function NavigationBar() {
+  const { t } = useTranslation();
+  return (
+    <nav className="fixed inset-x-0 bottom-0 mx-auto flex w-full max-w-[500px]
+      flex-row items-center justify-evenly bg-white"
+    >
+      <Link
+        to="/prompt"
+        className="flex grow justify-center py-4"
+      >
+        <PiClipboard size="1.7rem" aria-label={t('navigationBar.prompt')} />
+      </Link>
+      <Link
+        to="/mypage"
+        className="flex grow justify-center py-4"
+      >
+        <BsPerson size="1.7rem" aria-label={t('navigationBar.myPage')} />
+      </Link>
+      <Link
+        to="/"
+        className="flex grow justify-center py-4"
+      >
+        <GoHome size="1.7rem" aria-label={t('navigationBar.home')} />
+      </Link>
+      <Link
+        to="/search"
+        className="flex grow justify-center py-4"
+      >
+        <GoSearch size="1.7rem" aria-label={t('navigationBar.search')} />
+      </Link>
+      <button
+        type="button"
+        className="flex grow justify-center py-4"
+      >
+        <PiMoon size="1.7rem" aria-label={t('navigationBar.darkMode')} />
+      </button>
+    </nav>
+  );
+}

--- a/src/components/layouts/navigationBar.tsx
+++ b/src/components/layouts/navigationBar.tsx
@@ -2,44 +2,47 @@ import { useTranslation } from 'react-i18next';
 import { BsPerson } from 'react-icons/bs';
 import { GoHome, GoSearch } from 'react-icons/go';
 import { PiMoon, PiClipboard } from 'react-icons/pi';
-import { Link } from 'react-router-dom';
+import { Link, Outlet } from 'react-router-dom';
 
 export default function NavigationBar() {
   const { t } = useTranslation();
   return (
-    <nav className="fixed inset-x-0 bottom-0 mx-auto flex w-full max-w-[500px]
+    <>
+      <Outlet />
+      <nav className="fixed inset-x-0 bottom-0 mx-auto flex w-full max-w-[500px]
       flex-row items-center justify-evenly bg-white"
-    >
-      <Link
-        to="/prompt"
-        className="flex grow justify-center py-4"
       >
-        <PiClipboard size="1.7rem" aria-label={t('navigationBar.prompt')} />
-      </Link>
-      <Link
-        to="/mypage"
-        className="flex grow justify-center py-4"
-      >
-        <BsPerson size="1.7rem" aria-label={t('navigationBar.myPage')} />
-      </Link>
-      <Link
-        to="/"
-        className="flex grow justify-center py-4"
-      >
-        <GoHome size="1.7rem" aria-label={t('navigationBar.home')} />
-      </Link>
-      <Link
-        to="/search"
-        className="flex grow justify-center py-4"
-      >
-        <GoSearch size="1.7rem" aria-label={t('navigationBar.search')} />
-      </Link>
-      <button
-        type="button"
-        className="flex grow justify-center py-4"
-      >
-        <PiMoon size="1.7rem" aria-label={t('navigationBar.darkMode')} />
-      </button>
-    </nav>
+        <Link
+          to="/prompt"
+          className="flex grow justify-center py-4"
+        >
+          <PiClipboard size="1.7rem" aria-label={t('navigationBar.prompt')} />
+        </Link>
+        <Link
+          to="/mypage"
+          className="flex grow justify-center py-4"
+        >
+          <BsPerson size="1.7rem" aria-label={t('navigationBar.myPage')} />
+        </Link>
+        <Link
+          to="/"
+          className="flex grow justify-center py-4"
+        >
+          <GoHome size="1.7rem" aria-label={t('navigationBar.home')} />
+        </Link>
+        <Link
+          to="/search"
+          className="flex grow justify-center py-4"
+        >
+          <GoSearch size="1.7rem" aria-label={t('navigationBar.search')} />
+        </Link>
+        <button
+          type="button"
+          className="flex grow justify-center py-4"
+        >
+          <PiMoon size="1.7rem" aria-label={t('navigationBar.darkMode')} />
+        </button>
+      </nav>
+    </>
   );
 }

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -19,8 +19,13 @@ i18n
     resources: {
       ko: {
         translation: {
-          common: {
-            selected: '선택됨',
+          navigationBar: {
+            prompt: '프롬프트 페이지로 이동',
+            myPage: '마이 페이지로 이동',
+            home: '메인 페이지로 이동',
+            search: '검색 페이지로 이동',
+            darkMode: '다크 모드로 전환',
+            lightMode: '라이트 모드로 전환',
           },
           landingPage: {
             d1: '다른 나라의 음식점에서도 쉽게 주문하고 싶으신가요?',
@@ -33,10 +38,15 @@ i18n
         },
       },
       en: {
+        navigationBar: {
+          prompt: 'Move to prompt page',
+          myPage: 'Move to my page',
+          home: 'Move to main page',
+          search: 'Move to search page',
+          darkMode: 'Switch to dark mode',
+          lightMode: 'Switch to light mode',
+        },
         translation: {
-          common: {
-            selected: 'selected',
-          },
           landingPage: {
             d1: 'Do you want to order easily from restaurants in other countries?',
             d2: ' will help you',


### PR DESCRIPTION
resolve #4 

## 작업 내용
- 하단 네비게이션 바를 구현했습니다.
- 각 아이콘에 `aria-label` 속성을 적용시켜 접근성 문제를 해결했습니다.

![image](https://github.com/Step3-kakao-tech-campus/Team4_FE/assets/89011648/5e507159-5210-44cd-9833-c1a354b5ec34)