### PR TITLE
버튼 컴포넌트 구현

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,7 +10,8 @@
   "rules": {
     "react/react-in-jsx-scope": "off",
     "react/jsx-props-no-spreading": "off",
-    "import/prefer-default-export": "off"
+    "import/prefer-default-export": "off",
+    "react/require-default-props": "off"
   },
   "env": {
     "node": true,

--- a/src/components/atoms/button.tsx
+++ b/src/components/atoms/button.tsx
@@ -1,14 +1,24 @@
 import { ButtonHTMLAttributes } from 'react';
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  size?: 'small' | 'medium';
+  backgroundColor?: string;
+  textColor?: string;
   children: React.ReactNode;
 }
 
-export default function Button({ children, ...props }: ButtonProps) {
+export default function Button({
+  size = 'medium',
+  backgroundColor = 'bg-matgpt-blue',
+  textColor = 'text-white',
+  children,
+  ...props
+}: ButtonProps) {
   return (
     <button
       type="button"
-      className="rounded-full bg-matgpt-blue px-8 py-2 text-white"
+      className={`${size === 'medium' ? 'px-8 py-2 text-base' : 'px-4 py-1 text-xs'} 
+        ${backgroundColor} ${textColor} break-keep rounded-full`}
       {...props}
     >
       {children}

--- a/src/components/atoms/button.tsx
+++ b/src/components/atoms/button.tsx
@@ -4,6 +4,7 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   size?: 'small' | 'medium';
   backgroundColor?: string;
   textColor?: string;
+  extraStyle?: string;
   children: React.ReactNode;
 }
 
@@ -11,15 +12,16 @@ export default function Button({
   size = 'medium',
   backgroundColor = 'bg-matgpt-blue',
   textColor = 'text-white',
+  extraStyle = '',
   children,
   ...props
 }: ButtonProps) {
   return (
     <button
       type="button"
-      className={`${size === 'medium' ? 'px-8 py-2 text-base' : 'px-4 py-1 text-xs'} 
-        ${backgroundColor} ${textColor} break-keep rounded-full`}
       {...props}
+      className={`${size === 'medium' ? 'px-8 py-2 text-base' : 'px-4 py-1 text-xs'} 
+        ${backgroundColor} ${textColor} break-keep rounded-full ${extraStyle}`}
     >
       {children}
     </button>


### PR DESCRIPTION
resolve #21 

## 작업 내용
### props
- **`size`** : `'small'`과 `'medium'` 두 가지로 나뉨
- **`backgroundColor`**
- **`textColor`**
- **`extraStyle`** : 추가적인 스타일링을 위함

`backgroundColor`와 `textColor`, `extraStyle`은 tailwindcss 클래스명을 전달받습니다.

## 그 외 변경 사항
eslint의 `react/require-default-props` 옵션을 비활성화 하였습니다.
TypeScript 환경에서 default parameter와 interface를 사용하므로 해당 rule과 충돌을 일으켜 lint 에러가 발생합니다.
https://stackoverflow.com/questions/63696724/eslint-problem-with-default-props-in-functional-component-typescript-react
https://onethegarden.github.io/blog/react-typescript-default-props/
