### PR TITLE
메뉴 태그 컴포넌트 구현

### DIFF
--- a/src/components/atoms/input.tsx
+++ b/src/components/atoms/input.tsx
@@ -1,5 +1,5 @@
 import {
-  useRef, forwardRef, useImperativeHandle,
+  useRef, forwardRef, useImperativeHandle, useEffect,
 } from 'react';
 import { useTranslation } from 'react-i18next';
 import { GoSearch } from 'react-icons/go';
@@ -7,12 +7,16 @@ import { RefHandler } from '../../types/refHandler';
 
 interface InputProps {
   mode: 'search' | 'singleLine' | 'multiLine';
+  placeholder?: string;
+  defaultValue?: string;
   onSearchClick? : React.FormEventHandler<HTMLFormElement>;
 }
 
 const Input = forwardRef<RefHandler, InputProps>((
   {
     mode,
+    placeholder,
+    defaultValue,
     onSearchClick = (e) => { e.preventDefault(); },
   },
   ref,
@@ -31,6 +35,16 @@ const Input = forwardRef<RefHandler, InputProps>((
     },
   }));
 
+  useEffect(() => {
+    if (defaultValue !== undefined) {
+      if ((mode === 'search' || mode === 'singleLine') && inputRef.current !== null) {
+        inputRef.current.value = defaultValue;
+      } else if (mode === 'multiLine' && textareaRef.current !== null) {
+        textareaRef.current.value = defaultValue;
+      }
+    }
+  }, []);
+
   if (mode === 'search') {
     return (
       <form
@@ -41,6 +55,7 @@ const Input = forwardRef<RefHandler, InputProps>((
           type="text"
           ref={inputRef}
           className="w-full focus:outline-none"
+          placeholder={placeholder}
         />
         <button type="submit">
           <GoSearch size="1.2rem" aria-label={t('input.search')} />
@@ -56,6 +71,7 @@ const Input = forwardRef<RefHandler, InputProps>((
           type="text"
           ref={inputRef}
           className="w-full focus:outline-none"
+          placeholder={placeholder}
         />
       </div>
     );
@@ -66,6 +82,7 @@ const Input = forwardRef<RefHandler, InputProps>((
       <textarea
         ref={textareaRef}
         className="h-full w-full resize-none p-4"
+        placeholder={placeholder}
       />
     );
   }

--- a/src/components/molecules/menuTag.tsx
+++ b/src/components/molecules/menuTag.tsx
@@ -1,0 +1,78 @@
+import { forwardRef, useState } from 'react';
+import { RefHandler } from '../../types/refHandler';
+import Input from '../atoms/input';
+import Button from '../atoms/button';
+
+interface MenuTagProps {
+  name: string;
+  mode: 'modify' | 'prompt';
+}
+
+const MenuTag = forwardRef<RefHandler, MenuTagProps>((
+  {
+    name,
+    mode,
+  },
+  ref,
+) => {
+  const [isModifying, setIsModifying] = useState(false);
+
+  if (mode === 'modify') {
+    return (
+      <div>
+        {isModifying ? (
+          <div className="relative flex w-[10rem] flex-col items-center">
+            <div className="flex flex-col gap-2 rounded-xl bg-black px-4 py-2">
+              <Input ref={ref} mode="singleLine" />
+              <div className="flex flex-row justify-around">
+                <Button
+                  size="small"
+                  textColor="text-black"
+                >
+                  수정
+                </Button>
+                <Button
+                  size="small"
+                  backgroundColor="bg-matgpt-gray"
+                  textColor="text-black"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setIsModifying(false);
+                  }}
+                >
+                  취소
+                </Button>
+              </div>
+            </div>
+            <div className="w-4 border-[0.75rem] border-transparent border-t-black" />
+          </div>
+        ) : (
+          <div className="relative flex w-[10rem] flex-col items-center">
+            <button
+              type="button"
+              className="relative rounded-xl bg-black px-4 py-2"
+              onClick={() => setIsModifying(true)}
+            >
+              <span className="text-white">{name}</span>
+            </button>
+            <div className="w-4 border-[0.5rem] border-transparent border-t-black" />
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  if (mode === 'prompt') {
+    return (
+      <>
+      </>
+    );
+  }
+
+  return (
+    <>
+    </>
+  );
+});
+
+export default MenuTag;

--- a/src/components/molecules/menuTag.tsx
+++ b/src/components/molecules/menuTag.tsx
@@ -15,12 +15,12 @@ const MenuTag = forwardRef<RefHandler, MenuTagProps>((
   },
   ref,
 ) => {
-  const [isModifying, setIsModifying] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(false);
 
   if (mode === 'modify') {
     return (
       <div>
-        {isModifying ? (
+        {isExpanded ? (
           <div className="relative flex w-[10rem] flex-col items-center">
             <div className="flex flex-col gap-2 rounded-xl bg-black px-4 py-2">
               <Input ref={ref} mode="singleLine" />
@@ -37,7 +37,7 @@ const MenuTag = forwardRef<RefHandler, MenuTagProps>((
                   textColor="text-black"
                   onClick={(e) => {
                     e.stopPropagation();
-                    setIsModifying(false);
+                    setIsExpanded(false);
                   }}
                 >
                   취소
@@ -50,8 +50,8 @@ const MenuTag = forwardRef<RefHandler, MenuTagProps>((
           <div className="relative flex w-[10rem] flex-col items-center">
             <button
               type="button"
-              className="relative rounded-xl bg-black px-4 py-2"
-              onClick={() => setIsModifying(true)}
+              className="rounded-xl bg-black px-4 py-2"
+              onClick={() => setIsExpanded(true)}
             >
               <span className="text-white">{name}</span>
             </button>
@@ -64,8 +64,47 @@ const MenuTag = forwardRef<RefHandler, MenuTagProps>((
 
   if (mode === 'prompt') {
     return (
-      <>
-      </>
+      <div>
+        {isExpanded ? (
+          <div className="relative flex w-[10rem] flex-col items-center">
+            <section className="flex flex-col rounded-xl bg-black px-4 py-2 text-white">
+              <h3>{name}</h3>
+              <p>프롬프트에 추가하시겠습니까?</p>
+              <div className="mt-1 flex flex-row justify-around">
+                <Button
+                  size="small"
+                  textColor="text-black"
+                >
+                  추가
+                </Button>
+                <Button
+                  size="small"
+                  backgroundColor="bg-matgpt-gray"
+                  textColor="text-black"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setIsExpanded(false);
+                  }}
+                >
+                  취소
+                </Button>
+              </div>
+            </section>
+            <div className="w-4 border-[0.75rem] border-transparent border-t-black" />
+          </div>
+        ) : (
+          <div className="relative flex w-[10rem] flex-col items-center">
+            <button
+              type="button"
+              className="rounded-xl bg-black px-4 py-2"
+              onClick={() => setIsExpanded(true)}
+            >
+              <span className="text-white">{name}</span>
+            </button>
+            <div className="w-4 border-[0.5rem] border-transparent border-t-black" />
+          </div>
+        ) }
+      </div>
     );
   }
 

--- a/src/components/molecules/menuTag.tsx
+++ b/src/components/molecules/menuTag.tsx
@@ -1,4 +1,5 @@
 import { forwardRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { RefHandler } from '../../types/refHandler';
 import Input from '../atoms/input';
 import Button from '../atoms/button';
@@ -40,6 +41,7 @@ const MenuTag = forwardRef<RefHandler, MenuTagProps>((
   ref,
 ) => {
   const [isExpanded, setIsExpanded] = useState(false);
+  const { t } = useTranslation();
 
   if (mode === 'modify') {
     return (
@@ -54,7 +56,7 @@ const MenuTag = forwardRef<RefHandler, MenuTagProps>((
                   textColor="text-black"
                   onClick={onModifyEvent}
                 >
-                  수정
+                  {t('menuTag.modify')}
                 </Button>
                 <Button
                   size="small"
@@ -62,7 +64,7 @@ const MenuTag = forwardRef<RefHandler, MenuTagProps>((
                   textColor="text-black"
                   onClick={() => setIsExpanded(false)}
                 >
-                  취소
+                  {t('menuTag.cancel')}
                 </Button>
               </div>
             </div>
@@ -82,14 +84,14 @@ const MenuTag = forwardRef<RefHandler, MenuTagProps>((
           <div className="relative flex w-[10rem] flex-col items-center">
             <section className="flex flex-col gap-1 rounded-xl bg-black px-4 py-2 text-white">
               <h3 className="font-bold">{name}</h3>
-              <p className="text-xs">프롬프트에 추가하시겠습니까?</p>
-              <div className="flex flex-row justify-around">
+              <p className="text-xs">{t('menuTag.prompt')}</p>
+              <div className="mt-1 flex flex-row justify-around">
                 <Button
                   size="small"
                   textColor="text-black"
                   onClick={onPromptEvent}
                 >
-                  추가
+                  {t('menuTag.add')}
                 </Button>
                 <Button
                   size="small"
@@ -97,7 +99,7 @@ const MenuTag = forwardRef<RefHandler, MenuTagProps>((
                   textColor="text-black"
                   onClick={() => setIsExpanded(false)}
                 >
-                  취소
+                  {t('menuTag.cancel')}
                 </Button>
               </div>
             </section>

--- a/src/components/molecules/menuTag.tsx
+++ b/src/components/molecules/menuTag.tsx
@@ -27,7 +27,7 @@ const MenuTag = forwardRef<RefHandler, MenuTagProps>((
         {isExpanded ? (
           <div className="relative flex w-[10rem] flex-col items-center">
             <div className="flex flex-col gap-2 rounded-xl bg-black px-4 py-2">
-              <Input ref={ref} mode="singleLine" />
+              <Input ref={ref} mode="singleLine" defaultValue={name} />
               <div className="flex flex-row justify-around">
                 <Button
                   size="small"
@@ -46,7 +46,7 @@ const MenuTag = forwardRef<RefHandler, MenuTagProps>((
                 </Button>
               </div>
             </div>
-            <div className="w-4 border-[0.75rem] border-transparent border-t-black" />
+            <div className="w-4 border-[0.5rem] border-transparent border-t-black" />
           </div>
         ) : (
           <div className="relative flex w-[10rem] flex-col items-center">
@@ -90,7 +90,7 @@ const MenuTag = forwardRef<RefHandler, MenuTagProps>((
                 </Button>
               </div>
             </section>
-            <div className="w-4 border-[0.75rem] border-transparent border-t-black" />
+            <div className="w-4 border-[0.5rem] border-transparent border-t-black" />
           </div>
         ) : (
           <div className="relative flex w-[10rem] flex-col items-center">

--- a/src/components/molecules/menuTag.tsx
+++ b/src/components/molecules/menuTag.tsx
@@ -6,12 +6,16 @@ import Button from '../atoms/button';
 interface MenuTagProps {
   name: string;
   mode: 'modify' | 'prompt';
+  onModifyEvent?: React.MouseEventHandler<HTMLButtonElement>;
+  onPromptEvent?: React.MouseEventHandler<HTMLButtonElement>;
 }
 
 const MenuTag = forwardRef<RefHandler, MenuTagProps>((
   {
     name,
     mode,
+    onModifyEvent = () => {},
+    onPromptEvent = () => {},
   },
   ref,
 ) => {
@@ -28,6 +32,7 @@ const MenuTag = forwardRef<RefHandler, MenuTagProps>((
                 <Button
                   size="small"
                   textColor="text-black"
+                  onClick={onModifyEvent}
                 >
                   수정
                 </Button>
@@ -35,10 +40,7 @@ const MenuTag = forwardRef<RefHandler, MenuTagProps>((
                   size="small"
                   backgroundColor="bg-matgpt-gray"
                   textColor="text-black"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setIsExpanded(false);
-                  }}
+                  onClick={() => setIsExpanded(false)}
                 >
                   취소
                 </Button>
@@ -74,6 +76,7 @@ const MenuTag = forwardRef<RefHandler, MenuTagProps>((
                 <Button
                   size="small"
                   textColor="text-black"
+                  onClick={onPromptEvent}
                 >
                   추가
                 </Button>
@@ -81,10 +84,7 @@ const MenuTag = forwardRef<RefHandler, MenuTagProps>((
                   size="small"
                   backgroundColor="bg-matgpt-gray"
                   textColor="text-black"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setIsExpanded(false);
-                  }}
+                  onClick={() => setIsExpanded(false)}
                 >
                   취소
                 </Button>

--- a/src/components/molecules/menuTag.tsx
+++ b/src/components/molecules/menuTag.tsx
@@ -3,6 +3,26 @@ import { RefHandler } from '../../types/refHandler';
 import Input from '../atoms/input';
 import Button from '../atoms/button';
 
+interface DefaultTagProps {
+  name: string;
+  onClick: React.MouseEventHandler<HTMLButtonElement>;
+}
+
+function DefaultTag({ name, onClick }: DefaultTagProps) {
+  return (
+    <div className="relative flex w-[10rem] flex-col items-center">
+      <button
+        type="button"
+        className="flex rounded-lg bg-black px-3 py-2"
+        onClick={onClick}
+      >
+        <span className="text-sm text-white">{name}</span>
+      </button>
+      <div className="w-4 border-[0.5rem] border-transparent border-t-black" />
+    </div>
+  );
+}
+
 interface MenuTagProps {
   name: string;
   mode: 'modify' | 'prompt';
@@ -49,16 +69,7 @@ const MenuTag = forwardRef<RefHandler, MenuTagProps>((
             <div className="w-4 border-[0.5rem] border-transparent border-t-black" />
           </div>
         ) : (
-          <div className="relative flex w-[10rem] flex-col items-center">
-            <button
-              type="button"
-              className="rounded-xl bg-black px-4 py-2"
-              onClick={() => setIsExpanded(true)}
-            >
-              <span className="text-white">{name}</span>
-            </button>
-            <div className="w-4 border-[0.5rem] border-transparent border-t-black" />
-          </div>
+          <DefaultTag name={name} onClick={() => setIsExpanded(true)} />
         )}
       </div>
     );
@@ -69,10 +80,10 @@ const MenuTag = forwardRef<RefHandler, MenuTagProps>((
       <div>
         {isExpanded ? (
           <div className="relative flex w-[10rem] flex-col items-center">
-            <section className="flex flex-col rounded-xl bg-black px-4 py-2 text-white">
-              <h3>{name}</h3>
-              <p>프롬프트에 추가하시겠습니까?</p>
-              <div className="mt-1 flex flex-row justify-around">
+            <section className="flex flex-col gap-1 rounded-xl bg-black px-4 py-2 text-white">
+              <h3 className="font-bold">{name}</h3>
+              <p className="text-xs">프롬프트에 추가하시겠습니까?</p>
+              <div className="flex flex-row justify-around">
                 <Button
                   size="small"
                   textColor="text-black"
@@ -93,16 +104,7 @@ const MenuTag = forwardRef<RefHandler, MenuTagProps>((
             <div className="w-4 border-[0.5rem] border-transparent border-t-black" />
           </div>
         ) : (
-          <div className="relative flex w-[10rem] flex-col items-center">
-            <button
-              type="button"
-              className="rounded-xl bg-black px-4 py-2"
-              onClick={() => setIsExpanded(true)}
-            >
-              <span className="text-white">{name}</span>
-            </button>
-            <div className="w-4 border-[0.5rem] border-transparent border-t-black" />
-          </div>
+          <DefaultTag name={name} onClick={() => setIsExpanded(true)} />
         ) }
       </div>
     );

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -59,6 +59,12 @@ i18n
             loginGoogle: 'Google 계정으로 로그인',
             loginKakao: '카카오 로그인',
           },
+          menuTag: {
+            modify: '수정',
+            add: '추가',
+            cancel: '취소',
+            prompt: '프롬프트에 추가 하시겠습니까?',
+          },
         },
       },
       en: {
@@ -99,6 +105,12 @@ i18n
             kakaoLogo: 'Kakao Logo',
             loginGoogle: 'Sign in with Google',
             loginKakao: 'Login with Kakao',
+          },
+          menuTag: {
+            modify: 'Modify',
+            add: 'Add',
+            cancel: 'Cancel',
+            prompt: 'Would you like to add it to the prompt?',
           },
         },
       },


### PR DESCRIPTION
## 작업 내용
![image](https://github.com/Step3-kakao-tech-campus/Team4_FE/assets/89011648/30c5928a-d6d4-4e74-916e-4a63e5b276c4)
![image](https://github.com/Step3-kakao-tech-campus/Team4_FE/assets/89011648/e94b5b56-92ec-4ee6-a93a-e8ef4666374a)
![image](https://github.com/Step3-kakao-tech-campus/Team4_FE/assets/89011648/53e04b50-6fba-4d9b-bbf8-386bcc2145fa)

## 컴포넌트 props
- `name`: 메뉴 이름
- `mode`: 태그 클릭 시 메뉴 이름을 수정하는 컴포넌트로 전환 할 지, 프롬프트에 메뉴를 추가하는 컴포넌트로 전환 할 지 설정. 각각 `'modify'`와 `'prompt'`로 설정
- `onModifyEvent`: 메뉴 이름 수정 버튼을 눌렀을 때 호출할 이벤트
- `onPromptEvent`: 프롬프트 추가 버튼을 눌렀을 때 호출할 이벤트

## 그 외 변경사항
- `<Input>`컴포넌트에 `placeholder`, `defaultValue` 두 개의 props를 추가하였습니다.
- `defaultValue`를 통해 input 또는 textarea에 미리 입력될 값을 전달합니다.