### PR TITLE
Feature/image carousel 이미지캐러셀 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "react-router-dom": "^6.16.0",
         "react-scripts": "5.0.1",
         "sort-by": "^1.2.0",
+        "swiper": "^10.3.1",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
@@ -21378,6 +21379,24 @@
         "boolbase": "~1.0.0"
       }
     },
+    "node_modules/swiper": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-10.3.1.tgz",
+      "integrity": "sha512-24Wk3YUdZHxjc9faID97GTu6xnLNia+adMt6qMTZG/HgdSUt4fS0REsGUXJOgpTED0Amh/j+gRGQxsLayJUlBQ==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/swiperjs"
+        },
+        {
+          "type": "open_collective",
+          "url": "http://opencollective.com/swiper"
+        }
+      ],
+      "engines": {
+        "node": ">= 4.7.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -38641,6 +38660,11 @@
           }
         }
       }
+    },
+    "swiper": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-10.3.1.tgz",
+      "integrity": "sha512-24Wk3YUdZHxjc9faID97GTu6xnLNia+adMt6qMTZG/HgdSUt4fS0REsGUXJOgpTED0Amh/j+gRGQxsLayJUlBQ=="
     },
     "symbol-tree": {
       "version": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react-router-dom": "^6.16.0",
     "react-scripts": "5.0.1",
     "sort-by": "^1.2.0",
+    "swiper": "^10.3.1",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,6 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import LandingPage from './components/page/landingPage';
 import UserPage from './components/page/userPage';
-import SocialLoginModal from './components/socialLoginModal';
 
 function App() {
   return (
@@ -10,7 +9,6 @@ function App() {
         <Route>
           <Route path="/landing" element={<LandingPage />} />
           <Route path="/mypage" element={<UserPage />} />
-          <Route path="/test" element={<SocialLoginModal />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/src/components/molecules/css/carouselCss.css
+++ b/src/components/molecules/css/carouselCss.css
@@ -1,0 +1,18 @@
+.swiper-button-prev,
+.swiper-button-next {
+  background-color: #fff;
+  opacity: 0.5;
+  padding: 15px 5px;
+  border-radius: 20px;
+  color: black !important;
+}
+
+.swiper-button-prev:after,
+.swiper-button-next:after {
+  font-size: 1.1rem !important;
+  font-weight: 600 !important;
+}
+
+.swiper-pagination-bullet {
+  background: black !important;
+}

--- a/src/components/molecules/imageCarousel.tsx
+++ b/src/components/molecules/imageCarousel.tsx
@@ -4,6 +4,7 @@ import { Navigation, Pagination } from 'swiper/modules';
 import 'swiper/css';
 import 'swiper/css/navigation';
 import 'swiper/css/pagination';
+import './css/carouselCss.css';
 
 interface ImageCarouselType {
   swiperStyle: string;

--- a/src/components/molecules/imageCarousel.tsx
+++ b/src/components/molecules/imageCarousel.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Swiper, SwiperSlide } from 'swiper/react';
+import { Navigation, Pagination } from 'swiper/modules';
+import 'swiper/css';
+import 'swiper/css/navigation';
+import 'swiper/css/pagination';
+
+interface ImageCarouselType {
+  swiperStyle: string;
+  children: React.ReactNode;
+}
+
+function ImageCarousel({ swiperStyle, children }:ImageCarouselType) {
+  let global = 0;
+  const modifiedChildren = React.Children.map(children, (child) => {
+    global += 1;
+    return (
+      <SwiperSlide key={global}>
+        {child}
+      </SwiperSlide>
+    );
+  });
+  return (
+    <Swiper
+      modules={[Navigation, Pagination]}
+      slidesPerView={1}
+      navigation
+      pagination={{ clickable: true }}
+      className={swiperStyle}
+    >
+      {modifiedChildren}
+    </Swiper>
+  );
+}
+
+export default ImageCarousel;


### PR DESCRIPTION
## 작업내용
![bandicam 2023-10-10 15-13-30-824](https://github.com/Step3-kakao-tech-campus/Team4_FE/assets/87762581/13b5308b-cf73-41b2-b569-12a813caa2cc)
우선 css 디자인 바꿨는데 수정사항 있으면 comment 달아주세요.

## 컴포넌트 prop
- swiperStyle: 외부 캐러셀의 스타일을 className으로 전달하는 prop입니다.
- children: 캐러셀안의 카드들을 전달하는 prop입니다. 

## 그 외 변경 사항
molecule내부에 css폴더를 만들고 수정한 캐러셀 css파일을 넣어뒀습니다.
swiper 라이브러리를 설치하였습니다.
드래그와 버튼 두가지로 카드들을 넘겨볼 수 있게 하려고 이전 tailwind@material 라이브러리는 삭제하고, swiper 라이브러리르로 변경 했습니다.
