### PR TITLE
페이지 제목 카드 구현

### DIFF
--- a/src/components/molecules/pageTitleCard.tsx
+++ b/src/components/molecules/pageTitleCard.tsx
@@ -1,0 +1,18 @@
+import Icon from '../atoms/icon';
+
+interface PageTitleCardProps {
+  pageTitle: string;
+}
+
+export default function PageTitleCard({ pageTitle }: PageTitleCardProps) {
+  return (
+    <div className="flex w-full items-center gap-4 bg-matgpt-blue p-4 text-white">
+      <button type="button">
+        <Icon name="OutlineLeft" size="1.2rem" ariaLabel="뒤로 가기" />
+      </button>
+      <h1 className="flex grow items-center text-lg font-bold">
+        {pageTitle}
+      </h1>
+    </div>
+  );
+}

--- a/src/components/molecules/pageTitleCard.tsx
+++ b/src/components/molecules/pageTitleCard.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
 import Icon from '../atoms/icon';
 
 interface PageTitleCardProps {
@@ -7,9 +8,14 @@ interface PageTitleCardProps {
 
 export default function PageTitleCard({ pageTitle }: PageTitleCardProps) {
   const { t } = useTranslation();
+  const navigate = useNavigate();
+
   return (
     <div className="flex w-full items-center gap-4 bg-matgpt-blue p-4 text-white">
-      <button type="button">
+      <button
+        type="button"
+        onClick={() => navigate(-1)}
+      >
         <Icon name="OutlineLeft" size="1.2rem" ariaLabel={t('pageTitle.back')} />
       </button>
       <h1 className="flex grow items-center text-lg font-bold">

--- a/src/components/molecules/pageTitleCard.tsx
+++ b/src/components/molecules/pageTitleCard.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import Icon from '../atoms/icon';
 
 interface PageTitleCardProps {
@@ -5,10 +6,11 @@ interface PageTitleCardProps {
 }
 
 export default function PageTitleCard({ pageTitle }: PageTitleCardProps) {
+  const { t } = useTranslation();
   return (
     <div className="flex w-full items-center gap-4 bg-matgpt-blue p-4 text-white">
       <button type="button">
-        <Icon name="OutlineLeft" size="1.2rem" ariaLabel="뒤로 가기" />
+        <Icon name="OutlineLeft" size="1.2rem" ariaLabel={t('pageTitle.back')} />
       </button>
       <h1 className="flex grow items-center text-lg font-bold">
         {pageTitle}

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -74,6 +74,9 @@ i18n
             rating: '별점',
             review: '리뷰',
           },
+          pageTitle: {
+            back: '이전 페이지로 이동',
+          },
         },
       },
       en: {
@@ -129,6 +132,9 @@ i18n
             moveDetail: 'Move to the detail page',
             rating: 'Rating',
             review: 'Review',
+          },
+          pageTitle: {
+            back: 'Go to previous page',
           },
         },
       },


### PR DESCRIPTION
## 작업 내용
![image](https://github.com/Step3-kakao-tech-campus/Team4_FE/assets/89011648/497f73f9-36f1-4b88-91eb-5cab2ab295e2)

`react-router`의 `useNavigate()`를 사용해 뒤로 가기를 적용했습니다.