### PR TITLE
(회원가입) 유저 정보 입력 페이지 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ import ErrorBoundary from './components/layouts/errorBoundary';
 import NotFoundPage from './components/page/notFoundPage';
 import GlobalLoader from './components/atoms/globalLoader';
 import PromptPage from './components/page/promptPage';
+import RegisterUserInfoPage from './components/page/registerUserInfoPage';
 
 if (process.env.NODE_ENV === 'development') {
   worker.start({
@@ -60,6 +61,7 @@ function App() {
                     <Route path="/profileEditing" element={<UserEditProfilePage />} />
                     <Route path="/prompt/:promptId" element={<PromptPage />} />
                     <Route path="stores/:storeId/reviews/:reviewId" element={<ReviewDetailPage />} />
+                    <Route path="/registerUserInfo" element={<RegisterUserInfoPage />} />
                   </Route>
                   {/* 단독 레이아웃 */}
                   <Route path="/landing" element={<LandingPage />} />

--- a/src/apis/profile.ts
+++ b/src/apis/profile.ts
@@ -14,6 +14,16 @@ export async function profileEdit({ language, gender, nickname }: ProfileEditInf
   return response;
 }
 
+export async function profileCreate({ language, gender, nickname }: ProfileEditInfo)
+  : Promise<ResultType> {
+  const response = await fetchInstance.post('/create-profile', {
+    language,
+    gender,
+    nickname,
+  });
+  return response;
+}
+
 export async function getProfile(): Promise<ProfileInfo> {
   const response = await fetchInstance.get('/mypage/profile');
   return response.data;

--- a/src/components/molecules/pageTitleCard.tsx
+++ b/src/components/molecules/pageTitleCard.tsx
@@ -4,21 +4,27 @@ import Icon from '../atoms/icon';
 
 interface PageTitleCardProps {
   pageTitle: string;
+  isCanBackPage?: boolean;
+
 }
 
-export default function PageTitleCard({ pageTitle }: PageTitleCardProps) {
+export default function PageTitleCard({ pageTitle, isCanBackPage = true }: PageTitleCardProps) {
   const { t } = useTranslation();
   const navigate = useNavigate();
 
   return (
     <div className="flex w-full items-center gap-4 bg-matgpt-blue p-4 text-white">
-      <button
-        type="button"
-        onClick={() => navigate(-1)}
-      >
-        <Icon name="OutlineLeft" size="1.2rem" ariaLabel={t('pageTitle.back')} />
-      </button>
-      <h1 className="flex grow items-center text-lg font-bold">
+      {
+        isCanBackPage ? (
+          <button
+            type="button"
+            onClick={() => navigate(-1)}
+          >
+            <Icon name="OutlineLeft" size="1.2rem" ariaLabel={t('pageTitle.back')} />
+          </button>
+        ) : null
+      }
+      <h1 className={`flex grow items-center text-lg font-bold  ${isCanBackPage ? '' : 'justify-center'}`}>
         {pageTitle}
       </h1>
     </div>

--- a/src/components/organisms/editProfileForm.tsx
+++ b/src/components/organisms/editProfileForm.tsx
@@ -39,12 +39,12 @@ function EditProfileForm({ isRegister = false }: EditProfileFormProps) {
         return false;
       }
       console.log(language, gender);
-      if (language === '설정 안됨') {
-        alert('언어 정보가 선택되지 않았습니다.');
+      if (language === t('userEditProfilePage.notSelected')) {
+        alert(t('userEditProfilePage.languageNotSelectedError'));
         return false;
       }
-      if (gender === '설정 안됨') {
-        alert('성별 정보가 선택되지 않았습니다.');
+      if (gender === t('userEditProfilePage.notSelected')) {
+        alert(t('userEditProfilePage.genderNotSelectedError'));
         return false;
       }
       return true;
@@ -154,7 +154,7 @@ function EditProfileForm({ isRegister = false }: EditProfileFormProps) {
         </div>
       </div>
       <div className="my-24 text-center">
-        {isRegister ? <Button size="medium" extraStyle="px-12 mr-6" onClick={() => { onClickProfileCraete(); }}>회원정보 저장</Button> : (
+        {isRegister ? <Button size="medium" extraStyle="px-12 mr-6" onClick={() => { onClickProfileCraete(); }}>{t('userEditProfilePage.userInfoSave')}</Button> : (
           <div>
             <Button size="medium" extraStyle="px-12 mr-6" onClick={() => { onClickProfileEdit(); }}>{t('userEditProfilePage.change')}</Button>
             <Button size="medium" extraStyle="px-12 ml-6" backgroundColor="bg-matgpt-gray" onClick={() => { navigate('/mypage'); }}>{t('userEditProfilePage.cancel')}</Button>

--- a/src/components/page/registerUserInfoPage.tsx
+++ b/src/components/page/registerUserInfoPage.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import RegisterUserInfoTemplate from '../template/registerUserInfoTemplate';
+
+function RegisterUserInfoPage() {
+  return (
+    <RegisterUserInfoTemplate />
+  );
+}
+
+export default RegisterUserInfoPage;

--- a/src/components/template/registerUserInfoTemplate.tsx
+++ b/src/components/template/registerUserInfoTemplate.tsx
@@ -1,12 +1,18 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import EditProfileForm from '../organisms/editProfileForm';
 import EditProfileImage from '../organisms/editProfileImage';
+import PageTitleCard from '../molecules/pageTitleCard';
 
 function RegisterUserInfoTemplate() {
+  const { t } = useTranslation();
   return (
     <div>
-      <EditProfileImage />
-      <EditProfileForm />
+      <div className="bg-gradient-to-b from-matgpt-blue from-55% to-white to-45%">
+        <PageTitleCard pageTitle={t('registerUserInfoPage.pageTitle')} isCanBackPage={false} />
+        <EditProfileImage />
+      </div>
+      <EditProfileForm isRegister />
     </div>
   );
 }

--- a/src/components/template/registerUserInfoTemplate.tsx
+++ b/src/components/template/registerUserInfoTemplate.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import EditProfileForm from '../organisms/editProfileForm';
+import EditProfileImage from '../organisms/editProfileImage';
+
+function RegisterUserInfoTemplate() {
+  return (
+    <div>
+      <EditProfileImage />
+      <EditProfileForm />
+    </div>
+  );
+}
+
+export default RegisterUserInfoTemplate;

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -163,6 +163,8 @@ i18n
             notSelected: '설정 안됨',
             fileIsNotUpload: '파일이 업로드 되지 않았습니다.',
             userInfoSave: '회원정보 저장',
+            languageNotSelectedError: '언어 정보가 선택되지 않았습니다.',
+            genderNotSelectedError: '성별 정보가 선택되지 않았습니다.',
           },
           likedReviewPage: {
             pageTitle: '좋아요 한 리뷰',

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -162,6 +162,7 @@ i18n
             cancel: '취소',
             notSelected: '설정 안됨',
             fileIsNotUpload: '파일이 업로드 되지 않았습니다.',
+            userInfoSave: '회원정보 저장',
           },
           likedReviewPage: {
             pageTitle: '좋아요 한 리뷰',
@@ -228,6 +229,9 @@ i18n
           },
           promptPage: {
             confirm: '확인',
+          },
+          registerUserInfoPage: {
+            pageTitle: '유저 정보 입력',
           },
         },
       },
@@ -373,6 +377,7 @@ i18n
             cancel: 'Cancel',
             notSelected: 'not Selected',
             fileIsNotUpload: 'The file was not uploaded.',
+            userInfoSave: 'Save Your Information',
           },
           likedReviewPage: {
             pageTitle: 'Liked review',
@@ -439,6 +444,9 @@ i18n
           },
           promptPage: {
             confirm: 'Confrim',
+          },
+          registerUserInfoPage: {
+            pageTitle: 'Sign-up Page',
           },
         },
       },

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -421,7 +421,7 @@ export const handlers = [
       },
     }),
   )),
-  
+
   rest.post('/stores/:storeId/reviews/:reviewId/like', (req, res, ctx) => res(
     ctx.status(201),
     ctx.json({


### PR DESCRIPTION
## 구현 내용
![bandicam 2023-11-03 20-06-47-736](https://github.com/Step3-kakao-tech-campus/Team4_FE/assets/87762581/b4014b90-3919-4d86-8ba6-6a4e4fa27f9f)


- PageTitle Props추가 (기본 값 true로 되어 있는 isCanBackPage: 뒤로가기 기능이 있는 페이지 타이틀인가?)
-  EditProfileForm Props추가 (기본 값 false로 되어있는 isRegister: 첫 유저 정보 입력인지 / 수정인지 구분)
- 이외 EditProfileForm 컴포넌트 함수 모듈화 했습니다

## 추가 사항
- EditProfileImage 컴포넌트는 S3 업로드 기능 구현하면서 추가 수정 하겠습니다. 