### PR TITLE
리뷰 삭제 기능 구현

### DIFF
--- a/src/apis/review.ts
+++ b/src/apis/review.ts
@@ -46,3 +46,10 @@ export async function cancelLikeReview(
 ) {
   return fetchInstance.post(`/stores/${storeId}/reviews/${reviewId}/like-cancel`);
 }
+
+export async function deleteReview(
+  storeId: number,
+  reviewId: number,
+) {
+  return fetchInstance.delete(`/stores/${storeId}/reviews/${reviewId}`);
+}

--- a/src/components/atoms/socialLoginButton.tsx
+++ b/src/components/atoms/socialLoginButton.tsx
@@ -20,7 +20,7 @@ function SocialLoginButton({ name, size = 'medium' }: SocialLoginButtonProps) {
       <button
         type="button"
         onClick={() => { onClickHandleSocialLogin('kakao'); }}
-        className={`mb-2 flex h-[40px] items-center justify-center rounded-xl bg-white shadow-md ${size === 'medium' ? 'px-16' : 'px-[6.5rem]'}`}
+        className={`mb-2 flex h-[40px] items-center justify-center rounded-xl bg-white shadow-md ${size === 'medium' ? 'px-14' : 'px-[6.5rem]'}`}
       >
         <img src="/img/social-login/kakao-ballon.png" alt={t('loginModal.kakaoLogo')} className="w-6" />
         <span className="text-md ml-4">{t('loginModal.loginKakao')}</span>
@@ -32,7 +32,7 @@ function SocialLoginButton({ name, size = 'medium' }: SocialLoginButtonProps) {
       <button
         type="button"
         onClick={() => { onClickHandleSocialLogin('google'); }}
-        className={`mb-2 flex h-[40px] items-center justify-center rounded-xl bg-white shadow-md ${size === 'medium' ? 'px-6' : 'px-16'}`}
+        className={`mb-2 flex h-[40px] items-center justify-center rounded-xl bg-white shadow-md ${size === 'medium' ? 'px-4' : 'px-16'}`}
       >
         <img src="/img/social-login/google-logo.png" alt={t('loginModal.googleLogo')} className="w-6" />
         <span className="text-md ml-4 font-roboto">{t('loginModal.loginGoogle')}</span>

--- a/src/components/layouts/login.tsx
+++ b/src/components/layouts/login.tsx
@@ -8,7 +8,7 @@ function Login() {
   const navigate = useNavigate();
   useEffect(() => {
     // 로그인 상태인데 이 레이아웃에 들어오면 바로 메인 페이지로 이동
-    if (localStorage.getItem('accessToken') === null) { navigate('/'); }
+    if (localStorage.getItem('accessToken') !== null) { navigate('/'); }
   }, []);
 
   return (
@@ -25,10 +25,10 @@ function Login() {
       </div>
       <div>
         <div className="mb-6">
-          <SocialLoginButton size="medium" name="kakao" />
+          <SocialLoginButton size="large" name="kakao" />
         </div>
         <div>
-          <SocialLoginButton size="medium" name="google" />
+          <SocialLoginButton size="large" name="google" />
         </div>
       </div>
       <div className="mt-36">

--- a/src/components/modals/deleteReviewModal.tsx
+++ b/src/components/modals/deleteReviewModal.tsx
@@ -39,6 +39,16 @@ function DeleteReviewModal({ modalOpen, setModalOpen }: {
     setModalOpen(false);
   }
 
+  const onDeleteReviewClick = () => {
+    onCloseModalClick();
+    if (storeId === undefined || reviewId === undefined) {
+      return;
+    }
+    deleteReview(+storeId, +reviewId).then(() => {
+      navigate(`/stores/${storeId}`);
+    }).catch((error) => { console.log(error); });
+  };
+
   return (
     <ReactModal
       isOpen={modalOpen}
@@ -58,14 +68,7 @@ function DeleteReviewModal({ modalOpen, setModalOpen }: {
             size="medium"
             backgroundColor="bg-matgpt-red"
             textColor="text-black"
-            onClick={() => {
-              onCloseModalClick();
-              if (storeId === undefined || reviewId === undefined) {
-                return;
-              }
-              deleteReview(+storeId, +reviewId);
-              navigate(`/stores/${storeId}`);
-            }}
+            onClick={onDeleteReviewClick}
           >
             {t('deleteReviewModal.delete')}
           </Button>

--- a/src/components/modals/deleteReviewModal.tsx
+++ b/src/components/modals/deleteReviewModal.tsx
@@ -1,6 +1,7 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 import ReactModal from 'react-modal';
+import { useNavigate, useParams } from 'react-router-dom';
 import Button from '../atoms/button';
 
 const customModalStyles = {
@@ -25,9 +26,13 @@ const customModalStyles = {
   },
 };
 
-function DeleteReviewModal() {
+function DeleteReviewModal({ modalOpen, setModalOpen }: {
+  modalOpen: boolean,
+  setModalOpen: React.Dispatch<React.SetStateAction<boolean>>
+}) {
   const { t } = useTranslation();
-  const [modalOpen, setModalOpen] = useState(true);
+  const { storeId } = useParams();
+  const navigate = useNavigate();
 
   function onCloseModalClick() {
     setModalOpen(false);
@@ -37,6 +42,9 @@ function DeleteReviewModal() {
     <ReactModal
       isOpen={modalOpen}
       style={customModalStyles}
+      shouldCloseOnEsc
+      shouldCloseOnOverlayClick
+      onRequestClose={() => { onCloseModalClick(); }}
     >
       <div className="w-full flex-col justify-center justify-items-center">
         <div className="text-center">{t('deleteReviewModal.deleteTitle')}</div>
@@ -52,6 +60,7 @@ function DeleteReviewModal() {
             onClick={() => {
               onCloseModalClick();
               //  백앤드로 리뷰 삭제 요청을 보낸다.
+              navigate(`/stores/${storeId}`);
             }}
           >
             삭제

--- a/src/components/modals/deleteReviewModal.tsx
+++ b/src/components/modals/deleteReviewModal.tsx
@@ -67,7 +67,7 @@ function DeleteReviewModal({ modalOpen, setModalOpen }: {
               navigate(`/stores/${storeId}`);
             }}
           >
-            삭제
+            {t('deleteReviewModal.delete')}
           </Button>
         </div>
       </div>

--- a/src/components/modals/deleteReviewModal.tsx
+++ b/src/components/modals/deleteReviewModal.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import ReactModal from 'react-modal';
 import { useNavigate, useParams } from 'react-router-dom';
 import Button from '../atoms/button';
+import { deleteReview } from '../../apis/review';
 
 const customModalStyles = {
   overlay: {
@@ -31,7 +32,7 @@ function DeleteReviewModal({ modalOpen, setModalOpen }: {
   setModalOpen: React.Dispatch<React.SetStateAction<boolean>>
 }) {
   const { t } = useTranslation();
-  const { storeId } = useParams();
+  const { storeId, reviewId } = useParams();
   const navigate = useNavigate();
 
   function onCloseModalClick() {
@@ -59,7 +60,10 @@ function DeleteReviewModal({ modalOpen, setModalOpen }: {
             textColor="text-black"
             onClick={() => {
               onCloseModalClick();
-              //  백앤드로 리뷰 삭제 요청을 보낸다.
+              if (storeId === undefined || reviewId === undefined) {
+                return;
+              }
+              deleteReview(+storeId, +reviewId);
               navigate(`/stores/${storeId}`);
             }}
           >

--- a/src/components/modals/modalContainer.tsx
+++ b/src/components/modals/modalContainer.tsx
@@ -6,7 +6,6 @@ import { useModalSelector } from '../../hooks/store';
 import LanguageModal from './languageModal';
 import SocialLoginModalContent from './socialLoginModalContent';
 import SearchModal from './searchModal';
-import DeleteReviewModal from './deleteReviewModal';
 
 export default function ModalContainer({ children }: { children: React.ReactNode }) {
   const { type, isOpen } = useModalSelector((state) => state.modal);
@@ -84,17 +83,6 @@ export default function ModalContainer({ children }: { children: React.ReactNode
           <div role="dialog" aria-modal>
             <div ref={preNode} tabIndex={0} />
             <SearchModal />
-            <div ref={postNode} tabIndex={0} />
-          </div>
-        </ModalBackdrop>,
-        document.body,
-      ) : null}
-
-      {(isOpen && type === 'DeleteReview' && location.hash === '#DeleteReview') ? createPortal(
-        <ModalBackdrop>
-          <div role="dialog" aria-modal>
-            <div ref={preNode} tabIndex={0} />
-            <DeleteReviewModal />
             <div ref={postNode} tabIndex={0} />
           </div>
         </ModalBackdrop>,

--- a/src/components/molecules/reviewInformation.tsx
+++ b/src/components/molecules/reviewInformation.tsx
@@ -6,7 +6,7 @@ import Icon from '../atoms/icon';
 import Image from '../atoms/image';
 import { comma } from '../../utils/convert';
 import { likeReview, cancelLikeReview } from '../../apis/review';
-import { useModal } from '../../hooks/modal';
+import DeleteReviewModal from '../modals/deleteReviewModal';
 
 interface ReviewInformationProps {
   rating: number,
@@ -23,7 +23,7 @@ function ReviewInformation({
   const { t } = useTranslation();
   const { storeId, reviewId } = useParams();
   const [isLikeReview, setIsLikeReview] = useState(false);
-  const { openModal } = useModal('DeleteReview');
+  const [isOpenDeleteModal, setIsOpenDeleteModal] = useState(false);
 
   const { mutate: likeStoreMutation } = useMutation({
     mutationKey: 'likeStore',
@@ -72,7 +72,7 @@ function ReviewInformation({
               수정
             </span>
           </button>
-          <button type="button" onClick={openModal}>
+          <button type="button" onClick={() => { setIsOpenDeleteModal(true); }}>
             <span className="text-sm text-matgpt-gray">
               삭제
             </span>
@@ -87,6 +87,12 @@ function ReviewInformation({
         </div>
         <span>{comma(totalPrice)}</span>
       </div>
+      {isOpenDeleteModal ? (
+        <DeleteReviewModal
+          modalOpen={isOpenDeleteModal}
+          setModalOpen={setIsOpenDeleteModal}
+        />
+      ) : null}
     </div>
   );
 }

--- a/src/components/molecules/reviewInformation.tsx
+++ b/src/components/molecules/reviewInformation.tsx
@@ -6,6 +6,7 @@ import Icon from '../atoms/icon';
 import Image from '../atoms/image';
 import { comma } from '../../utils/convert';
 import { likeReview, cancelLikeReview } from '../../apis/review';
+import { useModal } from '../../hooks/modal';
 
 interface ReviewInformationProps {
   rating: number,
@@ -22,6 +23,7 @@ function ReviewInformation({
   const { t } = useTranslation();
   const { storeId, reviewId } = useParams();
   const [isLikeReview, setIsLikeReview] = useState(false);
+  const { openModal } = useModal('DeleteReview');
 
   const { mutate: likeStoreMutation } = useMutation({
     mutationKey: 'likeStore',
@@ -65,6 +67,16 @@ function ReviewInformation({
             <Image imageSrc={reviewerImage} alt={t('reviewDetailPage.reviewerProfileImage')} />
           </div>
           <span className="pl-[0.5rem]">{reviewerName}</span>
+          <button type="button">
+            <span className="mx-2 text-sm text-matgpt-gray">
+              수정
+            </span>
+          </button>
+          <button type="button" onClick={openModal}>
+            <span className="text-sm text-matgpt-gray">
+              삭제
+            </span>
+          </button>
         </div>
       </div>
       <div>

--- a/src/components/molecules/reviewInformation.tsx
+++ b/src/components/molecules/reviewInformation.tsx
@@ -72,12 +72,12 @@ function ReviewInformation({
             <div>
               <button type="button">
                 <span className="mx-2 text-sm text-matgpt-gray">
-                  수정
+                  {t('reviewDetailPage.edit')}
                 </span>
               </button>
               <button type="button" onClick={() => { setIsOpenDeleteModal(true); }}>
                 <span className="text-sm text-matgpt-gray">
-                  삭제
+                  {t('reviewDetailPage.delete')}
                 </span>
               </button>
             </div>

--- a/src/components/molecules/reviewInformation.tsx
+++ b/src/components/molecules/reviewInformation.tsx
@@ -15,10 +15,11 @@ interface ReviewInformationProps {
   reviewerImage: string,
   peopleCount: number,
   totalPrice: number,
+  isOwn: boolean,
 }
 
 function ReviewInformation({
-  rating, createdAt, reviewerName, reviewerImage, peopleCount, totalPrice,
+  rating, createdAt, reviewerName, reviewerImage, peopleCount, totalPrice, isOwn,
 }: ReviewInformationProps) {
   const { t } = useTranslation();
   const { storeId, reviewId } = useParams();
@@ -67,16 +68,20 @@ function ReviewInformation({
             <Image imageSrc={reviewerImage} alt={t('reviewDetailPage.reviewerProfileImage')} />
           </div>
           <span className="pl-[0.5rem]">{reviewerName}</span>
-          <button type="button">
-            <span className="mx-2 text-sm text-matgpt-gray">
-              수정
-            </span>
-          </button>
-          <button type="button" onClick={() => { setIsOpenDeleteModal(true); }}>
-            <span className="text-sm text-matgpt-gray">
-              삭제
-            </span>
-          </button>
+          {isOwn ? (
+            <div>
+              <button type="button">
+                <span className="mx-2 text-sm text-matgpt-gray">
+                  수정
+                </span>
+              </button>
+              <button type="button" onClick={() => { setIsOpenDeleteModal(true); }}>
+                <span className="text-sm text-matgpt-gray">
+                  삭제
+                </span>
+              </button>
+            </div>
+          ) : null}
         </div>
       </div>
       <div>

--- a/src/components/organisms/reviewImageCarousel.tsx
+++ b/src/components/organisms/reviewImageCarousel.tsx
@@ -17,7 +17,7 @@ function ReviewImageCarousel({ reviewImages, prompts, setPrompts }: ReviewImageC
   const { openModal } = useModal('Login');
 
   const onHandlePromptEvent = (name: string) => {
-    const token = localStorage.getItem('token');
+    const token = localStorage.getItem('accessTdoken');
     if (token === null) {
       openModal();
     } else if (prompts[name] === undefined) {

--- a/src/components/page/loginRedriect.tsx
+++ b/src/components/page/loginRedriect.tsx
@@ -14,6 +14,7 @@ function LoginRedriect() {
     localStorage.setItem('refreshToken', `Bearer ${refreshToken}`);
     localStorage.setItem('accessTokenExpiresIn', `${accessTokenExpiresIn}`);
 
+    // 백앤드에 api요청 보내서 닉네임, 이메일, 성별, 언어 정보 전역 상태 값에 저장
     if (isFirstLogin) {
       navigate('/registerUserInfo');
     } else {

--- a/src/components/template/reviewDetailTemplate.tsx
+++ b/src/components/template/reviewDetailTemplate.tsx
@@ -30,6 +30,7 @@ function ReviewDetailTemplate({ data }: ReviewDetailTemplateProps) {
         reviewerImage={data.reviewerImage}
         peopleCount={data.peopleCount}
         totalPrice={data.totalPrice}
+        isOwn={data.isOwn}
       />
       {isClick ? (
         <PromptEdit

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -100,6 +100,7 @@ i18n
             deleteTitle: '정말로 삭제하시겠습니까?',
             notRecovredTitle: '삭제된 리뷰는 복구할 수 없습니다.',
             cancel: '취소',
+            delete: '삭제',
           },
           storeDetail: {
             overview: '개요',
@@ -225,6 +226,8 @@ i18n
             num: ' 개',
             closePrompt: '프롬프트 수정 창 닫기',
             createPrompt: '프롬프트 생성',
+            edit: '수정',
+            delete: '삭제',
           },
           promptPage: {
             confirm: '확인',
@@ -314,6 +317,7 @@ i18n
             deleteTitle: 'Are you sure you want to delete it?',
             notRecovredTitle: 'Deleted reviews cannot be recovered.',
             cancel: 'Cancel',
+            delete: 'Delete',
           },
           storeDetail: {
             overview: 'Overview',
@@ -437,6 +441,8 @@ i18n
             num: ' Quantity.',
             closePrompt: 'Close the prompt editing window.',
             createPrompt: 'Create a prompt.',
+            edit: 'edit',
+            delete: 'delete',
           },
           promptPage: {
             confirm: 'Confrim',

--- a/src/types/review.ts
+++ b/src/types/review.ts
@@ -60,4 +60,5 @@ export interface ReviewDetailInfo {
   rating: number;
   peopleCount: number;
   totalPrice: number;
+  isOwn: boolean,
 }


### PR DESCRIPTION
## 구현 내용
![bandicam 2023-11-06 14-02-25-682](https://github.com/Step3-kakao-tech-campus/Team4_FE/assets/87762581/fc91b7cf-ef57-4e6d-a0fe-22d2d24e9ca8)
![bandicam 2023-11-06 14-02-29-247](https://github.com/Step3-kakao-tech-campus/Team4_FE/assets/87762581/7eef6a38-b449-44c8-ae70-5fd86c6979c8)

1. 리뷰 상세 페이지 api reponse에 isOwn(본인의 리뷰인지 아닌지) 값 추가
2. 리뷰 수정/삭제 버튼 추가
3. 삭제 버튼 클릭시 리뷰 삭제 모달창 띄우기
4. 리뷰 삭제 버튼 클릭시 리뷰 삭제 api 요청 후 성공할 시 음식점 페이지로 이동 


## 추가 사항
- 소셜 로그인 버튼 크기 수정, 로그인 레이아웃 에서 사용된 소셜 로그인 버튼 크기 수정
- 리뷰 삭제 시 S3에 업로드 되어있는 이미지들 삭제는 프론트가 할지 백이 할지 아직 못 정함