### PR TITLE
주문 프롬프트 페이지 구현

### DIFF
--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -1,3 +1,3 @@
 import { createFetchInstance } from '../utils/fetch';
 
-export const fetchInstance = createFetchInstance('/api', 1000);
+export const fetchInstance = createFetchInstance('/api', 5000);

--- a/src/apis/prompt.ts
+++ b/src/apis/prompt.ts
@@ -1,11 +1,7 @@
 import { fetchInstance } from './instance';
 
-export async function createPrompt(
-  storeId: number,
-  reviewId: number,
-  prompts: { [key: string]: number },
-) {
-  return fetchInstance.post(`/stores/${storeId}/reviews/${reviewId}/create-prompt`, prompts);
+export async function createPrompt() {
+  return fetchInstance.post('gpt/order');
 }
 
 export async function getPrompt(

--- a/src/components/molecules/promptList.tsx
+++ b/src/components/molecules/promptList.tsx
@@ -1,16 +1,20 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 import Icon from '../atoms/icon';
+import type { RootState } from '../../store';
+import { MenuNumber, DeleteMenu } from '../../store/slices/promptMenu';
 
 interface PromptListProps {
   menu: string,
-  number: number,
-  setPrompts: React.Dispatch<React.SetStateAction<{}>>,
-  prompts: { [key: string]: number },
 }
 
 function PromptList({
-  menu, number, setPrompts, prompts,
+  menu,
 }: PromptListProps) {
+  const prompts = useSelector((state: RootState) => state.promptMenu);
+  const [number, setNumber] = useState(prompts[menu]);
+  const dispatch = useDispatch();
+
   const onHandleMenuNumber = (type: 'plus' | 'minus') => {
     let newNumber = number;
     if (newNumber < 1) {
@@ -19,29 +23,15 @@ function PromptList({
     }
 
     if (type === 'plus') { newNumber += 1; } else { newNumber -= 1; }
-    setPrompts((prev) => ({
-      ...prev,
-      [menu]: newNumber,
-    }));
+    dispatch(MenuNumber({ menu, newNumber }));
+    setNumber(newNumber);
   };
 
-  const onHandleDeleteMenu = () => {
-    setPrompts((prev) => {
-      const newPrompts: { [key: string]: number } = {};
-      Object.keys(prev).map((key) => {
-        if (key !== menu) {
-          newPrompts[key] = prompts[key];
-        }
-        return true;
-      });
-      return ({ ...newPrompts });
-    });
-  };
   return (
     <div className="mb-8 flex items-center justify-between px-4">
       <span className="pl-2 text-2xl font-normal">{menu}</span>
       <div className="flex flex-col items-end">
-        <button type="button" onClick={() => { onHandleDeleteMenu(); }}>
+        <button type="button" onClick={() => { dispatch(DeleteMenu({ menu })); }}>
           <Icon name="OutlineClose" ariaLabel="메뉴 목록에서 삭제하기" size="1.5rem" />
         </button>
         <div className="flex pt-8">

--- a/src/components/organisms/promptEdit.tsx
+++ b/src/components/organisms/promptEdit.tsx
@@ -1,31 +1,28 @@
 import React from 'react';
 import { useMutation } from 'react-query';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { useSelector } from 'react-redux';
+import type { RootState } from '../../store';
 import Icon from '../atoms/icon';
 import PromptList from '../molecules/promptList';
 import Button from '../atoms/button';
 import { createPrompt } from '../../apis/prompt';
 
 interface PromptEditProps {
-  prompts: { [key: string]: number },
-  setPrompts: React.Dispatch<React.SetStateAction<{}>>,
   setIsClick: React.Dispatch<React.SetStateAction<boolean>>,
 }
 
-function PromptEdit({ prompts, setPrompts, setIsClick }: PromptEditProps) {
+function PromptEdit({ setIsClick }: PromptEditProps) {
   const { t } = useTranslation();
+  const prompts = useSelector((state: RootState) => state.promptMenu);
   const navigate = useNavigate();
-  const { storeId, reviewId } = useParams();
   const promptId = 1;
   const { mutate: createPromptMutation } = useMutation({ // post 요청 성공 시 promptId 값 받음 후에 수정 해야 함
     mutationKey: 'createPrompt',
-    mutationFn: () => {
-      if (storeId === undefined || reviewId === undefined) { return createPrompt(0, 0, {}); }
-      return createPrompt(+storeId, +reviewId, prompts);
-    },
+    mutationFn: () => createPrompt(),
     onSuccess: () => { alert(t('reviewDetailPage.successPromptCreate')); navigate(`/prompt/${promptId}`); },
-    onError: () => { alert(t('reviewDetailPage.failPromptCreate')); },
+    onError: () => { alert(t('reviewDetailPage.failPromptCreate')); navigate(`/prompt/${promptId}`); },
   });
 
   const onHandleCreatePrompt = () => {
@@ -57,9 +54,6 @@ function PromptEdit({ prompts, setPrompts, setIsClick }: PromptEditProps) {
             <div key={key}>
               <PromptList
                 menu={key}
-                number={prompts[key]}
-                setPrompts={setPrompts}
-                prompts={prompts}
               />
             </div>
           ))

--- a/src/components/organisms/reviewImageCarousel.tsx
+++ b/src/components/organisms/reviewImageCarousel.tsx
@@ -1,19 +1,22 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
+import { useSelector, useDispatch } from 'react-redux';
+import type { RootState } from '../../store';
 import ImageCarousel from '../molecules/imageCarousel';
 import { ReviewDetailImageInfo } from '../../types/review';
 import Image from '../atoms/image';
 import MenuTag from '../molecules/menuTag';
+import { AddMenu } from '../../store/slices/promptMenu';
 
 interface ReviewImageCarouselProps {
   reviewImages: ReviewDetailImageInfo[],
-  prompts: { [key: string]: number },
-  setPrompts: React.Dispatch<React.SetStateAction<{}>>;
 }
 
-function ReviewImageCarousel({ reviewImages, prompts, setPrompts }: ReviewImageCarouselProps) {
+function ReviewImageCarousel({ reviewImages }: ReviewImageCarouselProps) {
   const { t } = useTranslation();
+  const prompts = useSelector((state: RootState) => state.promptMenu);
+  const dispatch = useDispatch();
   const navigate = useNavigate();
   const { storeId, reviewId } = useParams();
   const onHandlePromptEvent = (name: string) => {
@@ -23,10 +26,7 @@ function ReviewImageCarousel({ reviewImages, prompts, setPrompts }: ReviewImageC
       navigate('/login');
     } else if (prompts[name] === undefined) {
       // 프롬프트에 메뉴가 없다면
-      setPrompts((prev) => ({
-        ...prev,
-        [name]: 1,
-      }));
+      dispatch(AddMenu({ menu: name }));
       alert(t('reviewDetailPage.menuAdd'));
     } else { // 프롬프트에 메뉴가 있다면
       alert(t('reviewDetailPage.alreadyAddMenu'));

--- a/src/components/page/promptPage.tsx
+++ b/src/components/page/promptPage.tsx
@@ -1,22 +1,12 @@
 import React, { useEffect } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
-import { useQuery } from 'react-query';
-import { getPrompt } from '../../apis/prompt';
+import { useSelector } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
+import type { RootState } from '../../store';
 import PromptTemplate from '../template/promptTemplate';
 
 function PromptPage() {
-  const { promptId } = useParams();
-  const { data, isLoading, isFetching } = useQuery({
-    queryKey: [`getPrompt?cursor=${promptId}`],
-    queryFn: () => {
-      if (promptId === undefined) {
-        return getPrompt(0);
-      }
-      return getPrompt(+promptId);
-    },
-  });
-
   const navigate = useNavigate();
+  const prompts = useSelector((state: RootState) => state.promptMenu);
   useEffect(() => {
     // 로그인 상태가 아니면 로그인 레이아웃으로 이동
     if (localStorage.getItem('accessToken') === null) {
@@ -26,15 +16,10 @@ function PromptPage() {
     }
   }, []);
 
-  if (data && !isLoading && !isFetching) {
-    return (
-      <PromptTemplate
-        prompt={data}
-      />
-    );
-  }
   return (
-    <div>Loading..</div>
+    <PromptTemplate
+      prompt={prompts}
+    />
   );
 }
 

--- a/src/components/page/reviewDetailPage.tsx
+++ b/src/components/page/reviewDetailPage.tsx
@@ -1,6 +1,8 @@
-import { useRef } from 'react';
+import { useRef, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { useDispatch } from 'react-redux';
+import { resetMenu } from '../../store/slices/promptMenu';
 import ReviewDetailTemplate from '../template/reviewDetailTemplate';
 import { editReview } from '../../apis/review';
 import { RefHandler } from '../../types/refHandler';
@@ -10,6 +12,7 @@ function ReviewDetailPage() {
   const { t } = useTranslation();
   const { storeId: si, reviewId: ri } = useParams();
   const InputRef = useRef<RefHandler>(null);
+  const dispatch = useDispatch();
 
   const storeId = Number(si);
   const reviewId = Number(ri);
@@ -32,6 +35,10 @@ function ReviewDetailPage() {
   if (Number.isNaN(reviewId) || Number.isNaN(storeId)) {
     return <div>{t('reviewDetailPage.wrongApiAccess')}</div>;
   }
+
+  useEffect(() => {
+    dispatch(resetMenu());
+  }, []);
 
   const { data, isLoading, isFetching } = useReviewDetail(storeId, reviewId);
 

--- a/src/components/template/reviewDetailTemplate.tsx
+++ b/src/components/template/reviewDetailTemplate.tsx
@@ -1,9 +1,11 @@
 import React, { useState, forwardRef } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useSelector } from 'react-redux';
 import ReviewImageCarousel from '../organisms/reviewImageCarousel';
 import ReviewInformation from '../molecules/reviewInformation';
 import PageTitleCard from '../molecules/pageTitleCard';
 import { ReviewDetailInfo } from '../../types/review';
+import { RootState } from '../../store';
 import Icon from '../atoms/icon';
 import PromptEdit from '../organisms/promptEdit';
 import Input from '../atoms/input';
@@ -25,9 +27,9 @@ const ReviewDetailTemplate = forwardRef<RefHandler, ReviewDetailTemplateProps>((
   ref,
 ) => {
   const { t, i18n } = useTranslation();
-  const [prompts, setPrompts] = useState({}); // 프롬프트 데이터를 저장할 상태 값
   const [isClick, setIsClick] = useState(false); // 프롬프트 창을 열었는지 확인하는 상태 값
   const [isEdit, setIsEdit] = useState(false); // 리뷰 수정 상태 안지 확인하는 상태 값
+  const prompts = useSelector((state: RootState) => state.promptMenu);
 
   const [isTranslated, setIsTranslated] = useState(false);
   const [translatedContent, setTranslatedContent] = useState('');
@@ -63,8 +65,6 @@ const ReviewDetailTemplate = forwardRef<RefHandler, ReviewDetailTemplateProps>((
       <PageTitleCard pageTitle={t('reviewDetailPage.pageTitle')} />
       <ReviewImageCarousel
         reviewImages={data.reviewImages}
-        prompts={prompts}
-        setPrompts={setPrompts}
       />
       <ReviewInformation
         rating={data.rating}
@@ -78,9 +78,7 @@ const ReviewDetailTemplate = forwardRef<RefHandler, ReviewDetailTemplateProps>((
       />
       {isClick ? (
         <PromptEdit
-          prompts={prompts}
           setIsClick={setIsClick}
-          setPrompts={setPrompts}
         />
       ) : (
         <div className="relative">

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,11 +1,13 @@
 import { configureStore } from '@reduxjs/toolkit';
 import { modalReducer } from './slices/modalSlice';
 import { menuTagReducer } from './slices/menuTagSlice';
+import { promptMenuReducer } from './slices/promptMenu';
 
 export const store = configureStore({
   reducer: {
     modal: modalReducer,
     menuTag: menuTagReducer,
+    promptMenu: promptMenuReducer,
   },
 });
 

--- a/src/store/slices/promptMenu.ts
+++ b/src/store/slices/promptMenu.ts
@@ -1,0 +1,49 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+const initialState: { [key: string]: number } = {
+};
+
+export const promptMenuSlice = createSlice({
+  name: 'promptMenu',
+  initialState,
+  reducers: {
+
+    MenuNumber: (state, action: PayloadAction<{
+      menu: string, newNumber: number
+    }>) => {
+      console.log(action.payload.newNumber); return ({
+        ...state,
+        [action.payload.menu]: action.payload.newNumber,
+      });
+    },
+
+    AddMenu: (state, action: PayloadAction<{
+      menu: string,
+    }>) => ({
+      ...state,
+      [action.payload.menu]: 1,
+    }),
+
+    DeleteMenu: (state, action: PayloadAction<{
+      menu: string,
+    }>) => {
+      const newPrompts: { [key: string]: number } = {};
+      Object.keys(state).map((key) => {
+        if (key !== action.payload.menu) {
+          newPrompts[key] = state[key];
+        }
+        return ({ ...newPrompts });
+      });
+    },
+
+    resetMenu: () => ({
+
+    }),
+
+  },
+});
+
+export const {
+  MenuNumber, AddMenu, DeleteMenu, resetMenu,
+} = promptMenuSlice.actions;
+export const promptMenuReducer = promptMenuSlice.reducer;


### PR DESCRIPTION
## 구현 내용
- 주문 프롬프트 상태 전역으로 관리
- api 주소 수정


## 문제점
- 주문 상세 페이지에서 주문 프롬프트 생성 후 백앤드에 저장이 안돼 전역 상태로 관리해서 프롬프트 페이지로 넘어가게끔 구현 했습니다. 

